### PR TITLE
chore: Add urls and metadata to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,15 @@
 name = "relrc"
 version = "0.4.1"
 edition = "2021"
+rust-version = "1.81"
 description = "Reference counted pointers, with relationships to other pointers."
+keywords = ["arc", "rc", "reference-counting", "mpi"]
+categories = ["concurrency", "memory-management", "rust-patterns"]
 readme = "README.md"
 license = "Apache-2.0"
+documentation = "https://docs.rs/relrc/"
+homepage = "https://github.com/lmondada/relrc"
+repository = "https://github.com/lmondada/relrc"
 
 [dependencies]
 derive-where = "1.2.7"


### PR DESCRIPTION
- Adds links to this repo, so we can reach it from the crates.io entry.
- Adds some keywords and categories (mostly copied from `archery`)
- Sets the MSRV. It's currently at 1.81 since we use `core::error` imports. Without it we could do 1.75 or earlier.