### PR TITLE
feat: Serialization of HistoryGraph

### DIFF
--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -83,6 +83,17 @@ impl<'r, N, E, R: EquivalenceResolver<N, E>> From<&'r R> for ResolverId<N, E, R>
     }
 }
 
+impl<N, E, R> From<ResolverId<N, E, R>> for String {
+    fn from(value: ResolverId<N, E, R>) -> Self {
+        value.id
+    }
+}
+
+/// Error type when resolver IDs mismatch.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Error)]
+#[error("Invalid resolver \"{0}\", expected \"{1}\"")]
+pub struct InvalidResolver(pub String, pub String);
+
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
@@ -91,7 +102,8 @@ pub(crate) mod tests {
     /// Two nodes are equivalent if the first element of their tuple is
     /// identical. All outgoing edges must have weight equal to the second
     /// element of the node's tuple.
-    #[derive(Debug, Clone, Default)]
+    #[derive(Debug, Copy, Clone, Default)]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     pub(crate) struct TestResolver;
 
     impl EquivalenceResolver<(usize, usize), usize> for TestResolver {

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -1,8 +1,11 @@
 //! Serialization and deserialization of [`RelRc`] objects.
 
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, str::FromStr};
 
-use crate::{EquivalenceResolver, HistoryGraph, NodeId, RelRc};
+use crate::{
+    resolver::{InvalidResolver, ResolverId},
+    EquivalenceResolver, HistoryGraph, NodeId, RelRc,
+};
 
 /// A serializable representation of a [`RelRc`] object.
 #[derive(Debug, Clone)]
@@ -10,6 +13,14 @@ use crate::{EquivalenceResolver, HistoryGraph, NodeId, RelRc};
 pub struct SerializedRelRc<N, E> {
     pub id: NodeId,
     pub ancestors: BTreeMap<NodeId, SerializedInnerData<N, E>>,
+}
+
+/// A serializable representation of a [`HistoryGraph`] object.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct SerializedHistoryGraph<N, E, R> {
+    pub nodes: BTreeMap<NodeId, SerializedInnerData<N, E>>,
+    pub resolver_id: ResolverId<N, E, R>,
 }
 
 /// A serializable representation of the inner data of a [`RelRc`] object.
@@ -57,43 +68,111 @@ impl<N: Clone, E: Clone> RelRc<N, E> {
 
     /// Convert a serializable representation of a [`RelRc`] object back to a
     /// [`RelRc`] object.
-    pub fn from_serialized(serialized: SerializedRelRc<N, E>) -> Self {
-        serialized.into()
+    pub fn from_serialized(mut serialized: SerializedRelRc<N, E>) -> Self {
+        let mut ancestors_deser = BTreeMap::new();
+        deserialize_node(
+            serialized.id,
+            &mut serialized.ancestors,
+            &mut ancestors_deser,
+        )
+        .clone()
+    }
+}
+
+impl<N: Clone, E: Clone, R: EquivalenceResolver<N, E>> HistoryGraph<N, E, R> {
+    /// Convert a [`HistoryGraph`] object to its serializable format.
+    pub fn to_serialized(&self) -> SerializedHistoryGraph<N, E, R> {
+        let mut nodes = BTreeMap::new();
+        for node_id in self.all_node_ids() {
+            let serialized = SerializedInnerData::serialize_inner_data(node_id, self);
+            nodes.insert(node_id, serialized);
+        }
+        SerializedHistoryGraph {
+            nodes,
+            resolver_id: self.resolver_id().into(),
+        }
+    }
+
+    /// Convert a serializable representation of a [`RelRc`] object back to a
+    /// [`RelRc`] object.
+    pub fn try_from_serialized(
+        mut serialized: SerializedHistoryGraph<N, E, R>,
+        resolver: R,
+    ) -> Result<Self, InvalidResolver> {
+        if ResolverId::from(&resolver) != serialized.resolver_id {
+            return Err(InvalidResolver(
+                resolver.id(),
+                serialized.resolver_id.into(),
+            ));
+        }
+        let mut ancestors_deser = BTreeMap::new();
+        while let Some(&node_id) = serialized.nodes.keys().next() {
+            deserialize_node(node_id, &mut serialized.nodes, &mut ancestors_deser);
+        }
+        Ok(HistoryGraph::new(ancestors_deser.into_values(), resolver))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for NodeId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for NodeId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        NodeId::from_str(&s).map_err(serde::de::Error::custom)
     }
 }
 
 impl<N: Clone, E: Clone> From<SerializedRelRc<N, E>> for RelRc<N, E> {
-    fn from(mut serialized: SerializedRelRc<N, E>) -> Self {
-        let mut ancestors = BTreeMap::new();
-        serialized.deserialize_node(serialized.id, &mut ancestors)
+    fn from(serialized: SerializedRelRc<N, E>) -> Self {
+        Self::from_serialized(serialized)
     }
 }
 
-impl<N, E> SerializedRelRc<N, E> {
-    fn deserialize_node(
-        &mut self,
-        node_id: NodeId,
-        ancestors: &mut BTreeMap<NodeId, RelRc<N, E>>,
-    ) -> RelRc<N, E> {
-        let node_serialized = self.ancestors.remove(&node_id).expect("invalid node_id");
-
-        // Recursively deserialize ancestors
-        for (parent_id, _) in node_serialized.incoming.iter() {
-            if !ancestors.contains_key(parent_id) {
-                let ancestor = self.deserialize_node(*parent_id, ancestors);
-                ancestors.insert(*parent_id, ancestor);
-            }
-        }
-
-        // Create incoming edges
-        let incoming = node_serialized
-            .incoming
-            .into_iter()
-            .map(|(parent_id, edge_value)| {
-                let parent = ancestors[&parent_id].clone();
-                (parent, edge_value)
-            });
-
-        RelRc::with_parents(node_serialized.value, incoming)
+impl<'g, N: Clone, E: Clone, R: EquivalenceResolver<N, E>> From<&'g HistoryGraph<N, E, R>>
+    for SerializedHistoryGraph<N, E, R>
+{
+    fn from(value: &'g HistoryGraph<N, E, R>) -> Self {
+        value.to_serialized()
     }
+}
+
+fn deserialize_node<'a, N: Clone, E: Clone>(
+    node_id: NodeId,
+    ancestors_ser: &mut BTreeMap<NodeId, SerializedInnerData<N, E>>,
+    ancestors_deser: &'a mut BTreeMap<NodeId, RelRc<N, E>>,
+) -> &'a RelRc<N, E> {
+    println!("popping node {}", node_id);
+    let node_ser = ancestors_ser.remove(&node_id).expect("invalid node_id");
+
+    // Recursively deserialize ancestors
+    for (parent_id, _) in node_ser.incoming.iter() {
+        if !ancestors_deser.contains_key(parent_id) {
+            deserialize_node(*parent_id, ancestors_ser, ancestors_deser);
+        }
+    }
+
+    // Create incoming edges
+    let incoming = node_ser
+        .incoming
+        .into_iter()
+        .map(|(parent_id, edge_value)| {
+            let parent = ancestors_deser[&parent_id].clone();
+            (parent, edge_value)
+        });
+
+    let node_deser = RelRc::with_parents(node_ser.value, incoming);
+    ancestors_deser.insert(node_id, node_deser.clone());
+    &ancestors_deser[&node_id]
 }

--- a/src/snapshots/relrc__history__tests__history_graph_serialization.snap
+++ b/src/snapshots/relrc__history__tests__history_graph_serialization.snap
@@ -1,0 +1,55 @@
+---
+source: src/history.rs
+expression: "serde_json::to_string_pretty(&serialized).unwrap()"
+---
+{
+  "nodes": {
+    "4d6bc93965c1357": {
+      "value": [
+        1,
+        20
+      ],
+      "incoming": [
+        [
+          "517cc1b727220a95",
+          10
+        ]
+      ]
+    },
+    "517cc1b727220a95": {
+      "value": [
+        1,
+        10
+      ],
+      "incoming": []
+    },
+    "9c8b5ce5aea2ba5a": {
+      "value": [
+        2,
+        30
+      ],
+      "incoming": [
+        [
+          "4d6bc93965c1357",
+          20
+        ]
+      ]
+    },
+    "ee081e9cd5c4c4ef": {
+      "value": [
+        3,
+        35
+      ],
+      "incoming": [
+        [
+          "4d6bc93965c1357",
+          20
+        ]
+      ]
+    }
+  },
+  "resolver_id": {
+    "id": "test_resolver",
+    "_marker": null
+  }
+}


### PR DESCRIPTION
- **Update readme**
- **chore: Release 0.4**
- **feat: Add HistoryGraph::children**
- **feat: relax petgraph dep**
- **feat: Infer equivalence from pointer equality**
- **feat: Add HistoryGraph::{contains, contains_id}**
- **chore: Release 0.4.1**
- **chore: Add urls and metadata to Cargo.toml (#6)**
- **feat: Serialization of HistoryGraph**
