### PR TITLE
chore!: Appease cargo-audit by replacing `fxhash`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,12 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,15 +185,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,11 +348,11 @@ version = "0.5.0"
 dependencies = [
  "derive-where",
  "derive_more",
- "fxhash",
  "insta",
  "itertools",
  "petgraph",
  "rstest",
+ "rustc-hash",
  "serde",
  "serde_json",
  "slotmap_fork_lmondada",
@@ -403,6 +388,12 @@ dependencies = [
  "syn",
  "unicode-ident",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ repository = "https://github.com/lmondada/relrc"
 [dependencies]
 derive-where = "1.2.7"
 derive_more = "0.99.18"
-fxhash = "0.2.1"
 # mpi = { version = "0.8.0", optional = true }
 petgraph = { version = ">= 0.6.5, < 0.9", default-features = false, optional = true }
 serde = { version = "1.0.204", optional = true, features = ["derive"] }
@@ -23,6 +22,7 @@ serde = { version = "1.0.204", optional = true, features = ["derive"] }
 slotmap_fork_lmondada = { version = "1.0.8" }
 thiserror = "1.0.63"
 itertools = "0.13.0"
+rustc-hash = "2.1.1"
 # futures = { version = "0.3.31", optional = true, default-features = false, features = [
 #     "executor",
 # ] }

--- a/src/node.rs
+++ b/src/node.rs
@@ -11,7 +11,7 @@ use std::{
 
 use derive_more::From;
 use derive_where::derive_where;
-use fxhash::FxHashSet;
+use rustc_hash::FxHashSet;
 
 use crate::Registry;
 use crate::{edge::InnerEdgeData, Edge, WeakEdge};

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -3,8 +3,8 @@
 use std::{cell::RefCell, collections::BTreeSet, rc::Rc};
 
 use derive_more::{From, Into};
-use fxhash::FxHashSet;
 use itertools::Itertools;
+use rustc_hash::FxHashSet;
 use slotmap_fork_lmondada::{SecondaryMap, SlotMap};
 
 use crate::{HistoryGraph, NodeId, Registry, RelRc};


### PR DESCRIPTION
Hello! And thanks for `relrc`, it's really interesting.

According to [`cargo-audit`](https://crates.io/crates/cargo-audit), `relrc` is vulnerable to a RUSTSEC advisory due to reliance on the unmaintained `fxhash`:

```
$ cargo audit
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 820 security advisories (from /Users/graham/.cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (73 crate dependencies)
Crate:     fxhash
Version:   0.2.1
Warning:   unmaintained
Title:     fxhash - no longer maintained
Date:      2025-09-05
ID:        RUSTSEC-2025-0057
URL:       https://rustsec.org/advisories/RUSTSEC-2025-0057
Dependency tree:
fxhash 0.2.1
└── relrc 0.5.0

warning: 1 allowed warning found
```

This tiny PR replaces `fxhash` with the suggested [`rustc-hash`](https://crates.io/crates/rustc-hash).